### PR TITLE
Adding relative path for repo assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ Duration: 3 hours
 
 Fast links:
 
-- [slides](https://github.com/DanielJohnHarty/intro-to-versioning/blob/master/content/slides.md)
-- [lab](https://github.com/DanielJohnHarty/intro-to-versioning/blob/master/content/lab.md)
-- [homework](https://github.com/DanielJohnHarty/intro-to-versioning/blob/master/content/homework.md)
-- [command-line-quickstart](https://github.com/DanielJohnHarty/intro-to-versioning/blob/master/content/command-line-quickstart.md)
-- [installing-git](https://github.com/DanielJohnHarty/intro-to-versioning/blob/master/content/installing-git.md)
-- [linux-terminal-commands-cheatsheet](https://github.com/DanielJohnHarty/intro-to-versioning/blob/master/content/linux-terminal-command-reference.md)
+- [slides](content/slides.md)
+- [lab](content/lab.md)
+- [homework](content/homework.md)
+- [command-line-quickstart](content/command-line-quickstart.md)
+- [installing-git](content/installing-git.md)
+- [linux-terminal-commands-cheatsheet](content/linux-terminal-command-reference.md)

--- a/content/slides.md
+++ b/content/slides.md
@@ -1,4 +1,4 @@
-![](https://github.com/DanielJohnHarty/intro-to-versioning/blob/master/content/image/adaltas-logo.png)<br><br>
+![](image/adaltas-logo.png)<br><br>
 <br><br>
 
 # Daniel Harty
@@ -45,7 +45,7 @@
 # Semantic Versioning (tag names)
 <br><br>
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ![](https://github.com/DanielJohnHarty/intro-to-versioning/blob/master/content/image/semver.png)
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ![](image/semver.png)
 <br>
 
 * MAJOR - when incompatible API changes
@@ -90,7 +90,7 @@
 # Local vs. remote git repository
 <br>
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ![](https://github.com/DanielJohnHarty/intro-to-versioning/blob/master/content/image/git-architecture.png)
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ![](image/git-architecture.png)
 
 <div style="page-break-after: always;"></div>
 
@@ -143,7 +143,7 @@ Resolved manually:
 
 *1 branch = 1 separate versioning space -> isolation of changes*
 
-![](https://github.com/DanielJohnHarty/intro-to-versioning/blob/master/content/image/git_branch.png)
+![](image/git_branch.png)
 
 <div style="page-break-after: always;"></div>
 


### PR DESCRIPTION
Relative image paths works in pdf generation and directly when viewing on github